### PR TITLE
Resolve np.int error.

### DIFF
--- a/deepfinder/utils/common.py
+++ b/deepfinder/utils/common.py
@@ -44,9 +44,9 @@ def plot_volume_orthoslices(vol, filename):
 
     # Get central slices along each dimension:
     dim = vol.shape
-    idx0 = np.int( np.round(dim[0]/2) )
-    idx1 = np.int( np.round(dim[1]/2) )
-    idx2 = np.int( np.round(dim[2]/2) )
+    idx0 = int( np.round(dim[0]/2) )
+    idx1 = int( np.round(dim[1]/2) )
+    idx2 = int( np.round(dim[2]/2) )
 
     slice0 = vol[idx0,:,:]
     slice1 = vol[:,idx1,:]

--- a/deepfinder/utils/smap.py
+++ b/deepfinder/utils/smap.py
@@ -21,9 +21,9 @@ def bin(scoremaps):
     """
     dim = scoremaps.shape
     Ncl = dim[3]
-    dimB0 = np.int(np.ceil(dim[0] / 2))
-    dimB1 = np.int(np.ceil(dim[1] / 2))
-    dimB2 = np.int(np.ceil(dim[2] / 2))
+    dimB0 = int(np.ceil(dim[0] / 2))
+    dimB1 = int(np.ceil(dim[1] / 2))
+    dimB2 = int(np.ceil(dim[2] / 2))
     dimB = (dimB0, dimB1, dimB2, Ncl)
     scoremapsB = np.zeros(dimB)
     for cl in range(0,Ncl):


### PR DESCRIPTION
Thanks for your work on this project!

When I run examples\training\step1_generate_target.py after following the install instructions, I get an error:

```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

This fix resolves this. 